### PR TITLE
Fix index error when no free models are configured

### DIFF
--- a/src/openwebui_token_tracking/pipes/base_tracked_pipe.py
+++ b/src/openwebui_token_tracking/pipes/base_tracked_pipe.py
@@ -143,12 +143,14 @@ class BaseTrackedPipe(ABC):
             ]
             max_credits = self.token_tracker.max_credits(user)
 
-            raise DailyTokenLimitExceededError(
+            message = (
                 f"You've exceeded the daily usage limit ({max_credits} credits) for the paid AI models. "
-f"\nYour usage will reset in {_time_to_midnight()}.\n"
+                f"\nYour usage will reset in {_time_to_midnight()}.\n"
                 f"If you would like to obtain more credits, please reach out to {os.environ.get('TOKEN_CREDIT_CONTACT_EMAIL', 'rc@dartmouth.edu')}.\n"
-                f"**IMPORTANT:** You can still use one of the free models (e.g., {free_models[0].name})."
             )
+            if free_models:
+                message += f"**IMPORTANT:** You can still use one of the free models (e.g., {free_models[0].name})."
+            raise DailyTokenLimitExceededError(message)
 
         return True
 


### PR DESCRIPTION
Currently an index error occures when the daily token usage is exceeded and no free models are configured.

<img width="1189" height="385" alt="grafik" src="https://github.com/user-attachments/assets/9ef4cb6f-2d49-4653-8e42-114a9bb72141" />

This fixes this by simply not including the free models message when no free models are configured.